### PR TITLE
Pin back python to avoid 'illegal instruction'

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5598c0a1a6eeb577bc271cac59983c89eb4c1beb1b7e75ba50068e2dc0c038f2
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win or py27]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
 
@@ -18,13 +18,13 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - python
+    - python<3.8
     - pip
     - setuptools >=42
     - pybind11 >=2.0
     - numpy >=1.10.0
   run:
-    - python
+    - python<3.8
     - numpy
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,20 +11,20 @@ source:
 
 build:
   number: 1
-  skip: True  # [win or py27]
+  skip: True  # [win or py>=38]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
 
 requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - python <3.8
+    - python
     - pip
     - setuptools >=42
     - pybind11 >=2.0
     - numpy >=1.10.0
   run:
-    - python <3.8
+    - python
     - numpy
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 1
-  skip: True  # [win or py>=38]
+  skip: True  # [win or py27 or py>=38]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,13 @@ requirements:
   build:
     - {{ compiler('cxx') }}
   host:
-    - python<3.8
+    - python <3.8
     - pip
     - setuptools >=42
     - pybind11 >=2.0
     - numpy >=1.10.0
   run:
-    - python<3.8
+    - python <3.8
     - numpy
 
 test:


### PR DESCRIPTION
As far as I can tell this currently fails with either py3.8 or py3.9:

```
> mamba create -n hnswlib python=3.8 hnswlib
source activate hnswlib
> python 
Python 3.8.6 | packaged by conda-forge | (default, Jan 25 2021, 23:21:18) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import hnswlib
Illegal instruction
```

Pin back until resolved?

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
